### PR TITLE
Merge incoming json with additional fields

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,5 +89,10 @@ func LogRaw(logger *log.Logger, fields map[string]interface{}, msg string) {
 // LogJSON logs all application/json types with request body as fields in the field 'json'
 func LogJSON(logger *log.Logger, fields map[string]interface{}, json map[string]interface{}) {
 	entry := log.NewEntry(logger)
-	entry.WithFields(fields).WithField("json", json).Info("")
+	msg := ""
+	if m, ok := json["msg"].(string); ok {
+		msg = m
+		delete(json, "msg")
+	}
+	entry.WithFields(fields).WithFields(json).Info(msg)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,18 @@ func TestJSONOutput(t *testing.T) {
 	log, status := run(t, "application/json", "{\"a\":1}")
 	assert.Equal(t, http.StatusOK, status)
 
-	assert.Contains(t, log, "\"json\":{\"a\":1}")
+	assert.Contains(t, log, "{\"a\":1,")
+	assert.Contains(t, log, "test-ns")
+	assert.Contains(t, log, "test-ot")
+	assert.Contains(t, log, "test-on")
+}
+
+func TestJSONOutputMsgFromOriginal(t *testing.T) {
+	log, status := run(t, "application/json", "{\"msg\":\"a\"}")
+	assert.Equal(t, http.StatusOK, status)
+
+	assert.Contains(t, log, "\"msg\":\"a\",")
+	assert.NotContains(t, log, "\"fields.msg\"")
 	assert.Contains(t, log, "test-ns")
 	assert.Contains(t, log, "test-ot")
 	assert.Contains(t, log, "test-on")


### PR DESCRIPTION
Allows ELK to parse original values as top level
json keys, not tucked under e.g. 'json: {}'