### PR TITLE
Enable build on RHEL

### DIFF
--- a/.make/docker.mk
+++ b/.make/docker.mk
@@ -1,3 +1,9 @@
+ifeq ($(TARGET),rhel)
+  DOCKERFILE_DEPLOY := Dockerfile.deploy.rhel
+else
+  DOCKERFILE_DEPLOY := Dockerfile.deploy
+endif
+
 DOCKER_IMAGE_CORE := $(PROJECT_NAME)
 DOCKER_IMAGE_DEPLOY := $(PROJECT_NAME)-deploy
 
@@ -30,13 +36,7 @@ docker-image-builder:
 .PHONY: docker-image-deploy
 ## Creates a runnable image using the artifacts from the bin directory.
 docker-image-deploy:
-	docker build -t $(DOCKER_IMAGE_DEPLOY) -f $(CUR_DIR)/Dockerfile.deploy $(CUR_DIR)
-
-.PHONY: docker-publish-deploy
-## Tags the runnable image and pushes it to the docker hub.
-docker-publish-deploy:
-	docker tag $(DOCKER_IMAGE_DEPLOY) openshiftio/${PROJECT_NAME}:latest
-	docker push openshiftio/${PROJECT_NAME}:latest
+	docker build -t $(DOCKER_IMAGE_DEPLOY) -f $(CUR_DIR)/$(DOCKERFILE_DEPLOY) $(CUR_DIR)
 
 .PHONY: docker-build-dir
 ## Creates the docker build directory.

--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,17 @@
+FROM prod.registry.access.redhat.com/rhel7
+ENV LANG=en_US.utf8
+ENV INSTALL_PREFIX=/usr/local/f8
+
+# Create a non-root user and a group with the same name: "f8"
+ENV USER_NAME=f8
+RUN useradd --no-create-home -s /bin/bash ${USER_NAME}
+
+COPY bin/tenant-log-indirector ${INSTALL_PREFIX}/bin/tenant-log-indirector
+
+# From here onwards, any RUN, CMD, or ENTRYPOINT will be run under the following user
+USER ${USER_NAME}
+
+WORKDIR ${INSTALL_PREFIX}
+ENTRYPOINT [ "bin/tenant-log-indirector" ]
+
+EXPOSE 8080

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -34,7 +34,7 @@ objects:
           deploymentconfig: tenant-log-indirector
       spec:
         containers:
-        - image: registry.devshift.net/openshiftio/tenant-log-indirector:${IMAGE_TAG}
+        - image: prod.registry.devshift.net/osio-prod/openshiftio/tenant-log-indirector:${IMAGE_TAG}
           imagePullPolicy: Always
           name: tenant-log-indirector
           ports:


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container. As of now, the CentOS containers will be the ones being deployed to prod-preview and prod.

cc: @jmelis @aslakknutsen 