### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/rhel:latest
+FROM quay.io/openshiftio/rhel-base-rhel:latest
 ENV LANG=en_US.utf8
 ENV INSTALL_PREFIX=/usr/local/f8
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -23,7 +23,7 @@ function load_jenkins_vars() {
             BUILD_URL \
             ghprbPullId)"
   fi
-
+}
 
 function install_deps() {
   # We need to disable selinux for now, XXX


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.